### PR TITLE
Remove global `serialize()` function.

### DIFF
--- a/django_qserializer/__init__.py
+++ b/django_qserializer/__init__.py
@@ -2,10 +2,8 @@ from .serialization import (
     BaseSerializer,
     SerializableManager,
     SerializableQuerySet,
-    serialize,
 )
 
 BaseSerializer = BaseSerializer
 SerializableManager = SerializableManager
 SerializableQuerySet = SerializableQuerySet
-serialize = serialize

--- a/django_qserializer/serialization.py
+++ b/django_qserializer/serialization.py
@@ -93,9 +93,6 @@ class BaseSerializer:
         """
         raise NotImplementedError
 
-    def serialize(self, objs):
-        yield from map(self._serialize_object, objs)
-
 
 class SerializableQuerySet(models.QuerySet):
     @property
@@ -136,15 +133,6 @@ class SerializableManager(BaseManager.from_queryset(SerializableQuerySet)):
         if serializer is None:
             serializer = self.default_serializer
         return self.get_queryset().to_serialize(serializer)
-
-
-def serialize(objs):
-    try:
-        obj = objs[0]
-    except IndexError:
-        return []
-    serializer = obj.serialize.serializer
-    return serializer.serialize(objs)
 
 
 class _FuncSerializer(BaseSerializer):

--- a/django_qserializer/tests/test_serializer.py
+++ b/django_qserializer/tests/test_serializer.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from django_qserializer import BaseSerializer, serialize
+from django_qserializer import BaseSerializer
 from django_qserializer.tests.testapp.models import Bus, Company, Travel
 
 
@@ -29,24 +29,6 @@ def test_magic_serialize_method(bus_fixture, django_assert_num_queries):
     bus = Bus.objects.to_serialize(S).first()
     with django_assert_num_queries(0):
         assert {'company': 'Hurricane Cart'} == bus.serialize()
-
-
-def test_global_serialize(bus_fixture, django_assert_num_queries):
-    class S(BaseSerializer):
-        select_related = ['company']
-
-        def serialize_object(self, bus):
-            return {
-                'company': bus.company.name,
-            }
-
-    bus = Bus.objects.to_serialize(S).first()
-    with django_assert_num_queries(0):
-        assert [{'company': 'Hurricane Cart'}] == list(serialize([bus]))
-
-
-def test_global_serialize_empty():
-    assert [] == serialize([])
 
 
 def test_serialize_object_not_implemented(bus_fixture):
@@ -93,9 +75,6 @@ def test_extras(bus_fixture, django_assert_num_queries):
 
     with django_assert_num_queries(0):
         assert expected == bus.serialize()
-
-    with django_assert_num_queries(0):
-        assert expected == next(serialize([bus]))
 
 
 def test_extras_recursive(bus_fixture, django_assert_num_queries):


### PR DESCRIPTION
This function was just a loop to call bounded `.serialize()`.