### PR TITLE
fix pyright error: Variable not allowed in type expression

### DIFF
--- a/django_qserializer/__init__.py
+++ b/django_qserializer/__init__.py
@@ -4,6 +4,4 @@ from .serialization import (
     SerializableQuerySet,
 )
 
-BaseSerializer = BaseSerializer
-SerializableManager = SerializableManager
-SerializableQuerySet = SerializableQuerySet
+__all__ = ["BaseSerializer", "SerializableManager", "SerializableQuerySet"]


### PR DESCRIPTION
The following code triggers an error in pyright because `SerializableManager` is a variable.

Not working example:

```
from django.db.models import Model
from django_qserialize import SerializableManager

class MyModel(Model):
    objects: SerializableManager = SerializableManager()
           # ^^ error here!
```